### PR TITLE
Fix issues with authenticated indexes

### DIFF
--- a/src/python_inspector/utils.py
+++ b/src/python_inspector/utils.py
@@ -24,7 +24,7 @@ import requests
 
 def get_netrc_auth(url, netrc):
     """
-    Return login and password if the hostname is in netrc
+    Return login and password if either the hostname is in netrc or a default is set in netrc
     else return login and password as None
     """
     hostname = urlparse(url).hostname
@@ -33,6 +33,11 @@ def get_netrc_auth(url, netrc):
         url_auth = hosts.get(hostname)
         # netrc returns a tuple of (login, account, password)
         return (url_auth[0], url_auth[2])
+
+    if "default" in hosts:
+        default_auth = hosts.get("default")
+        return (default_auth[0], default_auth[2])
+
     return (None, None)
 
 

--- a/src/python_inspector/utils.py
+++ b/src/python_inspector/utils.py
@@ -16,18 +16,21 @@ from typing import List
 from typing import NamedTuple
 from typing import Optional
 
+from urllib.parse import urlparse
+
 import aiohttp
 import requests
 
 
 def get_netrc_auth(url, netrc):
     """
-    Return login and password if url is in netrc
+    Return login and password if the hostname is in netrc
     else return login and password as None
     """
+    hostname = urlparse(url).hostname
     hosts = netrc.hosts
-    if url in hosts:
-        url_auth = hosts.get(url)
+    if hostname in hosts:
+        url_auth = hosts.get(hostname)
         # netrc returns a tuple of (login, account, password)
         return (url_auth[0], url_auth[2])
     return (None, None)

--- a/src/python_inspector/utils_pypi.py
+++ b/src/python_inspector/utils_pypi.py
@@ -1598,6 +1598,10 @@ class PypiSimpleRepository:
         name using the `index_url` of this repository.
         """
         package_url = f"{self.index_url}/{normalized_name}"
+
+        if not package_url.endswith("/"):
+            package_url += "/"
+
         text, _ = await CACHE.get(
             path_or_url=package_url,
             credentials=self.credentials,

--- a/src/python_inspector/utils_pypi.py
+++ b/src/python_inspector/utils_pypi.py
@@ -1797,7 +1797,10 @@ async def get_remote_file_content(
 
     auth = None
     if credentials:
-        auth = (credentials.get("login"), credentials.get("password"))
+        login = credentials.get("login")
+        password = credentials.get("password")
+        if login and password:
+            auth = aiohttp.BasicAuth(login, password)
 
     async with aiohttp.ClientSession() as session:
         async with session.get(url, allow_redirects=True, headers=headers, auth=auth) as response:

--- a/tests/data/test-commented.netrc
+++ b/tests/data/test-commented.netrc
@@ -1,2 +1,2 @@
-machine https://pyp2.org/simple login test password test123
-# machine https://pyp1.org/simple login test password test123
+machine pyp2.org login test password test123
+# machine pyp1.org login test password test123

--- a/tests/data/test-default.netrc
+++ b/tests/data/test-default.netrc
@@ -1,0 +1,2 @@
+machine example.com login test password test123
+default login defaultuser password defaultpass

--- a/tests/data/test.netrc
+++ b/tests/data/test.netrc
@@ -1,1 +1,2 @@
-machine https://pyp1.org/simple login test password test123
+machine pyp1.org login test password test123
+machine subdomain.example.com login subdomain-user password subdomain-secret

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -82,6 +82,20 @@ def test_get_netrc_auth_with_with_subdomains():
     )
 
 
+def test_get_netrc_auth_with_default():
+    netrc_file = test_env.get_test_loc("test-default.netrc")
+    parsed_netrc = netrc(netrc_file)
+
+    assert get_netrc_auth(url="https://example.com/simple", netrc=parsed_netrc) == (
+        "test",
+        "test123",
+    )
+    assert get_netrc_auth(url="https://non-existing.org/simple", netrc=parsed_netrc) == (
+        "defaultuser",
+        "defaultpass",
+    )
+
+
 @pytest.mark.asyncio
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
 @mock.patch("python_inspector.utils_pypi.CACHE.get")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,6 +35,25 @@ def test_get_netrc_auth():
     netrc_file = test_env.get_test_loc("test.netrc")
     parsed_netrc = netrc(netrc_file)
     assert get_netrc_auth(url="https://pyp1.org/simple", netrc=parsed_netrc) == ("test", "test123")
+    assert get_netrc_auth(url="https://pyp1.org/different/path", netrc=parsed_netrc) == (
+        "test",
+        "test123",
+    )
+    assert get_netrc_auth(url="https://pyp1.org", netrc=parsed_netrc) == ("test", "test123")
+
+
+def test_get_netrc_auth_with_ports_and_schemes():
+    netrc_file = test_env.get_test_loc("test.netrc")
+    parsed_netrc = netrc(netrc_file)
+
+    assert get_netrc_auth(url="https://pyp1.org:443/path", netrc=parsed_netrc) == (
+        "test",
+        "test123",
+    )
+    assert get_netrc_auth(url="http://pyp1.org:80/simple", netrc=parsed_netrc) == (
+        "test",
+        "test123",
+    )
 
 
 def test_get_commented_netrc_auth():
@@ -47,6 +66,20 @@ def test_get_netrc_auth_with_no_matching_url():
     netrc_file = test_env.get_test_loc("test.netrc")
     parsed_netrc = netrc(netrc_file)
     assert get_netrc_auth(url="https://pypi2.org/simple", netrc=parsed_netrc) == (None, None)
+
+
+def test_get_netrc_auth_with_with_subdomains():
+    netrc_file = test_env.get_test_loc("test.netrc")
+    parsed_netrc = netrc(netrc_file)
+
+    assert get_netrc_auth(url="https://subdomain.example.com/simple", netrc=parsed_netrc) == (
+        "subdomain-user",
+        "subdomain-secret",
+    )
+    assert get_netrc_auth(url="https://another.example.com/simple", netrc=parsed_netrc) == (
+        None,
+        None,
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR fixes two issues with the netrc handling of `python-inspector`:

1. Support host names in the netrc file, instead of relying on full URLs. This fixes #176.
2. Support the special `default` host name

Please take a look at the specific commits for details.

Resolves: #127 and #176