### PR TITLE
Use default `INDEX_URL` from Settings to use environment variables

### DIFF
--- a/src/python_inspector/resolve_cli.py
+++ b/src/python_inspector/resolve_cli.py
@@ -13,6 +13,7 @@ from typing import Dict
 
 import click
 
+from python_inspector import pyinspector_settings
 from python_inspector import settings
 from python_inspector import utils_pypi
 from python_inspector.cli_utils import FileOptionType
@@ -93,8 +94,7 @@ def print_version(ctx, param, value):
     type=str,
     metavar="INDEX",
     show_default=True,
-    # since multiple is True, this is a sequence
-    default=[settings.PYPI_SIMPLE_URL],
+    default=pyinspector_settings.INDEX_URL,
     multiple=True,
     help="PyPI simple index URL(s) to use in order of preference. "
     "This option can be used multiple times.",

--- a/tests/data/azure-devops.req-310-expected.json
+++ b/tests/data/azure-devops.req-310-expected.json
@@ -316,12 +316,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "certifi",
-      "version": "2025.6.15",
+      "version": "2025.7.14",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
       "description": "Python package for providing Mozilla's CA Bundle.\nCertifi: Python SSL Certificates\n================================\n\nCertifi provides Mozilla's carefully curated collection of Root Certificates for\nvalidating the trustworthiness of SSL certificates while verifying the identity\nof TLS hosts. It has been extracted from the `Requests`_ project.\n\nInstallation\n------------\n\n``certifi`` is available on PyPI. Simply install it with ``pip``::\n\n    $ pip install certifi\n\nUsage\n-----\n\nTo reference the installed certificate authority (CA) bundle, you can use the\nbuilt-in function::\n\n    >>> import certifi\n\n    >>> certifi.where()\n    '/usr/local/lib/python3.7/site-packages/certifi/cacert.pem'\n\nOr from the command line::\n\n    $ python -m certifi\n    /usr/local/lib/python3.7/site-packages/certifi/cacert.pem\n\nEnjoy!\n\n.. _`Requests`: https://requests.readthedocs.io/en/master/\n\nAddition/Removal of Certificates\n--------------------------------\n\nCertifi does not support any addition/removal or other modification of the\nCA trust store content. This project is intended to provide a reliable and\nhighly portable root of trust to python deployments. Look to upstream projects\nfor methods to use alternate trust.",
-      "release_date": "2025-06-15T02:45:49",
+      "release_date": "2025-07-14T03:29:26",
       "parties": [
         {
           "type": "person",
@@ -347,11 +347,11 @@
         "Programming Language :: Python :: 3.9"
       ],
       "homepage_url": "https://github.com/certifi/python-certifi",
-      "download_url": "https://files.pythonhosted.org/packages/84/ae/320161bd181fc06471eed047ecce67b693fd7515b16d495d8932db763426/certifi-2025.6.15-py3-none-any.whl",
-      "size": 157650,
+      "download_url": "https://files.pythonhosted.org/packages/4f/52/34c6cf5bb9285074dc3531c437b3919e825d976fde097a7a73f79e726d03/certifi-2025.7.14-py3-none-any.whl",
+      "size": 162722,
       "sha1": null,
-      "md5": "8845c8810c449703d1988932c38d3bea",
-      "sha256": "2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057",
+      "md5": "8561c6b29236cd268f57ddb4f22281d3",
+      "sha256": "6b31f564a415d79ee77df69d757bb49a5bb53bd9f756cbbe24394ffd6fc1f4b2",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/certifi/python-certifi",
@@ -371,9 +371,9 @@
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/certifi/2025.6.15/json",
+      "api_data_url": "https://pypi.org/pypi/certifi/2025.7.14/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/certifi@2025.6.15"
+      "purl": "pkg:pypi/certifi@2025.7.14"
     },
     {
       "type": "pypi",
@@ -1329,7 +1329,7 @@
       ]
     },
     {
-      "package": "pkg:pypi/certifi@2025.6.15",
+      "package": "pkg:pypi/certifi@2025.7.14",
       "dependencies": []
     },
     {
@@ -1364,7 +1364,7 @@
       "package": "pkg:pypi/msrest@0.7.1",
       "dependencies": [
         "pkg:pypi/azure-core@1.35.0",
-        "pkg:pypi/certifi@2025.6.15",
+        "pkg:pypi/certifi@2025.7.14",
         "pkg:pypi/isodate@0.7.2",
         "pkg:pypi/requests-oauthlib@2.0.0",
         "pkg:pypi/requests@2.32.4"
@@ -1388,7 +1388,7 @@
     {
       "package": "pkg:pypi/requests@2.32.4",
       "dependencies": [
-        "pkg:pypi/certifi@2025.6.15",
+        "pkg:pypi/certifi@2025.7.14",
         "pkg:pypi/charset-normalizer@3.4.2",
         "pkg:pypi/idna@3.10",
         "pkg:pypi/urllib3@2.5.0"

--- a/tests/data/azure-devops.req-312-expected.json
+++ b/tests/data/azure-devops.req-312-expected.json
@@ -316,12 +316,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "certifi",
-      "version": "2025.6.15",
+      "version": "2025.7.14",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
       "description": "Python package for providing Mozilla's CA Bundle.\nCertifi: Python SSL Certificates\n================================\n\nCertifi provides Mozilla's carefully curated collection of Root Certificates for\nvalidating the trustworthiness of SSL certificates while verifying the identity\nof TLS hosts. It has been extracted from the `Requests`_ project.\n\nInstallation\n------------\n\n``certifi`` is available on PyPI. Simply install it with ``pip``::\n\n    $ pip install certifi\n\nUsage\n-----\n\nTo reference the installed certificate authority (CA) bundle, you can use the\nbuilt-in function::\n\n    >>> import certifi\n\n    >>> certifi.where()\n    '/usr/local/lib/python3.7/site-packages/certifi/cacert.pem'\n\nOr from the command line::\n\n    $ python -m certifi\n    /usr/local/lib/python3.7/site-packages/certifi/cacert.pem\n\nEnjoy!\n\n.. _`Requests`: https://requests.readthedocs.io/en/master/\n\nAddition/Removal of Certificates\n--------------------------------\n\nCertifi does not support any addition/removal or other modification of the\nCA trust store content. This project is intended to provide a reliable and\nhighly portable root of trust to python deployments. Look to upstream projects\nfor methods to use alternate trust.",
-      "release_date": "2025-06-15T02:45:49",
+      "release_date": "2025-07-14T03:29:26",
       "parties": [
         {
           "type": "person",
@@ -347,11 +347,11 @@
         "Programming Language :: Python :: 3.9"
       ],
       "homepage_url": "https://github.com/certifi/python-certifi",
-      "download_url": "https://files.pythonhosted.org/packages/84/ae/320161bd181fc06471eed047ecce67b693fd7515b16d495d8932db763426/certifi-2025.6.15-py3-none-any.whl",
-      "size": 157650,
+      "download_url": "https://files.pythonhosted.org/packages/4f/52/34c6cf5bb9285074dc3531c437b3919e825d976fde097a7a73f79e726d03/certifi-2025.7.14-py3-none-any.whl",
+      "size": 162722,
       "sha1": null,
-      "md5": "8845c8810c449703d1988932c38d3bea",
-      "sha256": "2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057",
+      "md5": "8561c6b29236cd268f57ddb4f22281d3",
+      "sha256": "6b31f564a415d79ee77df69d757bb49a5bb53bd9f756cbbe24394ffd6fc1f4b2",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/certifi/python-certifi",
@@ -371,9 +371,9 @@
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/certifi/2025.6.15/json",
+      "api_data_url": "https://pypi.org/pypi/certifi/2025.7.14/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/certifi@2025.6.15"
+      "purl": "pkg:pypi/certifi@2025.7.14"
     },
     {
       "type": "pypi",
@@ -1329,7 +1329,7 @@
       ]
     },
     {
-      "package": "pkg:pypi/certifi@2025.6.15",
+      "package": "pkg:pypi/certifi@2025.7.14",
       "dependencies": []
     },
     {
@@ -1364,7 +1364,7 @@
       "package": "pkg:pypi/msrest@0.7.1",
       "dependencies": [
         "pkg:pypi/azure-core@1.35.0",
-        "pkg:pypi/certifi@2025.6.15",
+        "pkg:pypi/certifi@2025.7.14",
         "pkg:pypi/isodate@0.7.2",
         "pkg:pypi/requests-oauthlib@2.0.0",
         "pkg:pypi/requests@2.32.4"
@@ -1388,7 +1388,7 @@
     {
       "package": "pkg:pypi/requests@2.32.4",
       "dependencies": [
-        "pkg:pypi/certifi@2025.6.15",
+        "pkg:pypi/certifi@2025.7.14",
         "pkg:pypi/charset-normalizer@3.4.2",
         "pkg:pypi/idna@3.10",
         "pkg:pypi/urllib3@2.5.0"

--- a/tests/data/azure-devops.req-313-expected.json
+++ b/tests/data/azure-devops.req-313-expected.json
@@ -316,12 +316,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "certifi",
-      "version": "2025.6.15",
+      "version": "2025.7.14",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
       "description": "Python package for providing Mozilla's CA Bundle.\nCertifi: Python SSL Certificates\n================================\n\nCertifi provides Mozilla's carefully curated collection of Root Certificates for\nvalidating the trustworthiness of SSL certificates while verifying the identity\nof TLS hosts. It has been extracted from the `Requests`_ project.\n\nInstallation\n------------\n\n``certifi`` is available on PyPI. Simply install it with ``pip``::\n\n    $ pip install certifi\n\nUsage\n-----\n\nTo reference the installed certificate authority (CA) bundle, you can use the\nbuilt-in function::\n\n    >>> import certifi\n\n    >>> certifi.where()\n    '/usr/local/lib/python3.7/site-packages/certifi/cacert.pem'\n\nOr from the command line::\n\n    $ python -m certifi\n    /usr/local/lib/python3.7/site-packages/certifi/cacert.pem\n\nEnjoy!\n\n.. _`Requests`: https://requests.readthedocs.io/en/master/\n\nAddition/Removal of Certificates\n--------------------------------\n\nCertifi does not support any addition/removal or other modification of the\nCA trust store content. This project is intended to provide a reliable and\nhighly portable root of trust to python deployments. Look to upstream projects\nfor methods to use alternate trust.",
-      "release_date": "2025-06-15T02:45:49",
+      "release_date": "2025-07-14T03:29:26",
       "parties": [
         {
           "type": "person",
@@ -347,11 +347,11 @@
         "Programming Language :: Python :: 3.9"
       ],
       "homepage_url": "https://github.com/certifi/python-certifi",
-      "download_url": "https://files.pythonhosted.org/packages/84/ae/320161bd181fc06471eed047ecce67b693fd7515b16d495d8932db763426/certifi-2025.6.15-py3-none-any.whl",
-      "size": 157650,
+      "download_url": "https://files.pythonhosted.org/packages/4f/52/34c6cf5bb9285074dc3531c437b3919e825d976fde097a7a73f79e726d03/certifi-2025.7.14-py3-none-any.whl",
+      "size": 162722,
       "sha1": null,
-      "md5": "8845c8810c449703d1988932c38d3bea",
-      "sha256": "2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057",
+      "md5": "8561c6b29236cd268f57ddb4f22281d3",
+      "sha256": "6b31f564a415d79ee77df69d757bb49a5bb53bd9f756cbbe24394ffd6fc1f4b2",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/certifi/python-certifi",
@@ -371,9 +371,9 @@
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/certifi/2025.6.15/json",
+      "api_data_url": "https://pypi.org/pypi/certifi/2025.7.14/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/certifi@2025.6.15"
+      "purl": "pkg:pypi/certifi@2025.7.14"
     },
     {
       "type": "pypi",
@@ -1329,7 +1329,7 @@
       ]
     },
     {
-      "package": "pkg:pypi/certifi@2025.6.15",
+      "package": "pkg:pypi/certifi@2025.7.14",
       "dependencies": []
     },
     {
@@ -1364,7 +1364,7 @@
       "package": "pkg:pypi/msrest@0.7.1",
       "dependencies": [
         "pkg:pypi/azure-core@1.35.0",
-        "pkg:pypi/certifi@2025.6.15",
+        "pkg:pypi/certifi@2025.7.14",
         "pkg:pypi/isodate@0.7.2",
         "pkg:pypi/requests-oauthlib@2.0.0",
         "pkg:pypi/requests@2.32.4"
@@ -1388,7 +1388,7 @@
     {
       "package": "pkg:pypi/requests@2.32.4",
       "dependencies": [
-        "pkg:pypi/certifi@2025.6.15",
+        "pkg:pypi/certifi@2025.7.14",
         "pkg:pypi/charset-normalizer@3.4.2",
         "pkg:pypi/idna@3.10",
         "pkg:pypi/urllib3@2.5.0"

--- a/tests/data/azure-devops.req-38-expected.json
+++ b/tests/data/azure-devops.req-38-expected.json
@@ -317,12 +317,12 @@
       "type": "pypi",
       "namespace": null,
       "name": "certifi",
-      "version": "2025.6.15",
+      "version": "2025.7.14",
       "qualifiers": {},
       "subpath": null,
       "primary_language": "Python",
       "description": "Python package for providing Mozilla's CA Bundle.\nCertifi: Python SSL Certificates\n================================\n\nCertifi provides Mozilla's carefully curated collection of Root Certificates for\nvalidating the trustworthiness of SSL certificates while verifying the identity\nof TLS hosts. It has been extracted from the `Requests`_ project.\n\nInstallation\n------------\n\n``certifi`` is available on PyPI. Simply install it with ``pip``::\n\n    $ pip install certifi\n\nUsage\n-----\n\nTo reference the installed certificate authority (CA) bundle, you can use the\nbuilt-in function::\n\n    >>> import certifi\n\n    >>> certifi.where()\n    '/usr/local/lib/python3.7/site-packages/certifi/cacert.pem'\n\nOr from the command line::\n\n    $ python -m certifi\n    /usr/local/lib/python3.7/site-packages/certifi/cacert.pem\n\nEnjoy!\n\n.. _`Requests`: https://requests.readthedocs.io/en/master/\n\nAddition/Removal of Certificates\n--------------------------------\n\nCertifi does not support any addition/removal or other modification of the\nCA trust store content. This project is intended to provide a reliable and\nhighly portable root of trust to python deployments. Look to upstream projects\nfor methods to use alternate trust.",
-      "release_date": "2025-06-15T02:45:49",
+      "release_date": "2025-07-14T03:29:26",
       "parties": [
         {
           "type": "person",
@@ -348,11 +348,11 @@
         "Programming Language :: Python :: 3.9"
       ],
       "homepage_url": "https://github.com/certifi/python-certifi",
-      "download_url": "https://files.pythonhosted.org/packages/84/ae/320161bd181fc06471eed047ecce67b693fd7515b16d495d8932db763426/certifi-2025.6.15-py3-none-any.whl",
-      "size": 157650,
+      "download_url": "https://files.pythonhosted.org/packages/4f/52/34c6cf5bb9285074dc3531c437b3919e825d976fde097a7a73f79e726d03/certifi-2025.7.14-py3-none-any.whl",
+      "size": 162722,
       "sha1": null,
-      "md5": "8845c8810c449703d1988932c38d3bea",
-      "sha256": "2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057",
+      "md5": "8561c6b29236cd268f57ddb4f22281d3",
+      "sha256": "6b31f564a415d79ee77df69d757bb49a5bb53bd9f756cbbe24394ffd6fc1f4b2",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": "https://github.com/certifi/python-certifi",
@@ -372,9 +372,9 @@
       "dependencies": [],
       "repository_homepage_url": null,
       "repository_download_url": null,
-      "api_data_url": "https://pypi.org/pypi/certifi/2025.6.15/json",
+      "api_data_url": "https://pypi.org/pypi/certifi/2025.7.14/json",
       "datasource_id": null,
-      "purl": "pkg:pypi/certifi@2025.6.15"
+      "purl": "pkg:pypi/certifi@2025.7.14"
     },
     {
       "type": "pypi",
@@ -1339,7 +1339,7 @@
       ]
     },
     {
-      "package": "pkg:pypi/certifi@2025.6.15",
+      "package": "pkg:pypi/certifi@2025.7.14",
       "dependencies": []
     },
     {
@@ -1374,7 +1374,7 @@
       "package": "pkg:pypi/msrest@0.7.1",
       "dependencies": [
         "pkg:pypi/azure-core@1.33.0",
-        "pkg:pypi/certifi@2025.6.15",
+        "pkg:pypi/certifi@2025.7.14",
         "pkg:pypi/isodate@0.7.2",
         "pkg:pypi/requests-oauthlib@2.0.0",
         "pkg:pypi/requests@2.32.4"
@@ -1398,7 +1398,7 @@
     {
       "package": "pkg:pypi/requests@2.32.4",
       "dependencies": [
-        "pkg:pypi/certifi@2025.6.15",
+        "pkg:pypi/certifi@2025.7.14",
         "pkg:pypi/charset-normalizer@3.4.2",
         "pkg:pypi/idna@3.10",
         "pkg:pypi/urllib3@2.2.3"

--- a/tests/data/single-url-env-var-except-simple-expected.json
+++ b/tests/data/single-url-env-var-except-simple-expected.json
@@ -3,7 +3,7 @@
     "tool_name": "python-inspector",
     "tool_homepageurl": "https://github.com/aboutcode-org/python-inspector",
     "options": [
-      "--index-url https://pypi.org/simple",
+      "--index-url https://thirdparty.aboutcode.org/pypi/simple/",
       "--json <file>",
       "--operating-system linux",
       "--python-version 38",

--- a/tests/data/tilde_req-expected-env.json
+++ b/tests/data/tilde_req-expected-env.json
@@ -25,7 +25,7 @@
       "subpath": null,
       "primary_language": "Python",
       "description": "Backport of pathlib-compatible object wrapper for zip files\n.. image:: https://img.shields.io/pypi/v/zipp.svg\n   :target: `PyPI link`_\n\n.. image:: https://img.shields.io/pypi/pyversions/zipp.svg\n   :target: `PyPI link`_\n\n.. _PyPI link: https://pypi.org/project/zipp\n\n.. image:: https://github.com/jaraco/zipp/workflows/tests/badge.svg\n   :target: https://github.com/jaraco/zipp/actions?query=workflow%3A%22tests%22\n   :alt: tests\n\n.. image:: https://img.shields.io/badge/code%20style-black-000000.svg\n   :target: https://github.com/psf/black\n   :alt: Code style: Black\n\n.. .. image:: https://readthedocs.org/projects/skeleton/badge/?version=latest\n..    :target: https://skeleton.readthedocs.io/en/latest/?badge=latest\n\n.. image:: https://img.shields.io/badge/skeleton-2022-informational\n   :target: https://blog.jaraco.com/skeleton\n\n.. image:: https://tidelift.com/badges/package/pypi/zipp\n   :target: https://tidelift.com/subscription/pkg/pypi-zipp?utm_source=pypi-zipp&utm_medium=readme\n\n\nA pathlib-compatible Zipfile object wrapper. Official backport of the standard library\n`Path object <https://docs.python.org/3.8/library/zipfile.html#path-objects>`_.\n\n\nCompatibility\n=============\n\nNew features are introduced in this third-party library and later merged\ninto CPython. The following table indicates which versions of this library\nwere contributed to different versions in the standard library:\n\n.. list-table::\n   :header-rows: 1\n\n   * - zipp\n     - stdlib\n   * - 3.5\n     - 3.11\n   * - 3.3\n     - 3.9\n   * - 1.0\n     - 3.8\n\n\nUsage\n=====\n\nUse ``zipp.Path`` in place of ``zipfile.Path`` on any Python.\n\nFor Enterprise\n==============\n\nAvailable as part of the Tidelift Subscription.\n\nThis project and the maintainers of thousands of other packages are working with Tidelift to deliver one enterprise subscription that covers all of the open source you use.\n\n`Learn more <https://tidelift.com/subscription/pkg/pypi-zipp?utm_source=pypi-zipp&utm_medium=referral&utm_campaign=github>`_.\n\nSecurity Contact\n================\n\nTo report a security vulnerability, please use the\n`Tidelift security contact <https://tidelift.com/security>`_.\nTidelift will coordinate the fix and disclosure.",
-      "release_date": "2022-07-12T14:21:20",
+      "release_date": "2022-07-12T14:21:21",
       "parties": [
         {
           "type": "person",
@@ -42,11 +42,11 @@
         "Programming Language :: Python :: 3 :: Only"
       ],
       "homepage_url": "https://github.com/jaraco/zipp",
-      "download_url": "https://files.pythonhosted.org/packages/f0/36/639d6742bcc3ffdce8b85c31d79fcfae7bb04b95f0e5c4c6f8b206a038cc/zipp-3.8.1-py3-none-any.whl",
-      "size": 5645,
+      "download_url": "https://files.pythonhosted.org/packages/3b/e3/fb79a1ea5f3a7e9745f688855d3c673f2ef7921639a380ec76f7d4d83a85/zipp-3.8.1.tar.gz",
+      "size": 14189,
       "sha1": null,
-      "md5": "300aa262796e7ebfb57b4d6731821c29",
-      "sha256": "47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009",
+      "md5": "6f15c3e3c78919f8936749b0033e0cea",
+      "sha256": "05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
       "sha512": null,
       "bug_tracking_url": null,
       "code_view_url": null,

--- a/tests/data/tilde_req-expected-env.json
+++ b/tests/data/tilde_req-expected-env.json
@@ -4,6 +4,7 @@
     "tool_homepageurl": "https://github.com/aboutcode-org/python-inspector",
     "options": [
       "--index-url https://pypi.org/simple",
+      "--index-url https://thirdparty.aboutcode.org/pypi/simple",
       "--json <file>",
       "--operating-system linux",
       "--python-version 38",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -231,7 +231,7 @@ def test_cli_with_multiple_env_var_index_url_and_tilde_req():
     expected_file = test_env.get_test_loc("tilde_req-expected-env.json", must_exist=False)
     specifier = "zipp~=3.8.0"
     os.environ["PYINSP_INDEX_URL"] = (
-        "https://pypi.org/simple https://thirdparty.aboutcode.org/pypi/simple/"
+        "https://pypi.org/simple https://thirdparty.aboutcode.org/pypi/simple"
     )
     check_specs_resolution(
         specifier=specifier,


### PR DESCRIPTION
This was incorrectly removed in https://github.com/aboutcode-org/python-inspector/pull/225